### PR TITLE
Allow buildspec to be passed to build project

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ resource "aws_iam_role_policy_attachment" "codebuild_s3" {
 | name          | codebuild            | Name                                                                                                                           |
 | image         | alpine               | Docker image used as environment                                                                                               |
 | instance_size | BUILD_GENERAL1_SMALL | Instance size for job.  Possible values are: ```BUILD_GENERAL1_SMALL``` ```BUILD_GENERAL1_MEDIUM``` ```BUILD_GENERAL1_LARGE``` |
+| buildspec     | ""                   | Optional buildspec declaration to use for building the project                                                                 |
 
 ## Output
 

--- a/main.tf
+++ b/main.tf
@@ -73,7 +73,8 @@ resource "aws_codebuild_project" "default" {
   }
 
   source {
-    type = "CODEPIPELINE"
+    buildspec = "${var.buildspec}"
+    type      = "CODEPIPELINE"
   }
 
   tags = "${module.label.tags}"

--- a/variables.tf
+++ b/variables.tf
@@ -17,3 +17,8 @@ variable "image" {
 variable "instance_size" {
   default = "BUILD_GENERAL1_SMALL"
 }
+
+variable "buildspec" {
+  default     = ""
+  description = "Optional buildspec declaration to use for building the project"
+}


### PR DESCRIPTION
## what
*  allows the `buildspec` for the job to be passed into the module as a string

## why
* As an alternative method to providing the `buildspec` in code (preferred way)
* I'm not sure if this is the right way to do it as I'm still feeling my way into AWS codepipeline, but this change allows the buildspec for the job to be passed in to the module as a string.

Usage would look something like this:

```
module "build" {
  source    = ...
  namespace = "${var.namespace}"
  name      = "${var.name}-build"
  stage     = "${var.stage}"

  image         = "${var.build_image}"
  instance_size = "${var.build_instance_size}"
  buildspec     = "${file("${path.module}/files/buildspec.yaml")}"
}
```