### PR TITLE
Use `aws_iam_role_policy_attachment` instead of `aws_iam_policy_attachment`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -47,21 +47,21 @@ data "aws_iam_policy_document" "permissions" {
       "ecr:GetAuthorizationToken",
       "ecr:InitiateLayerUpload",
       "ecr:PutImage",
-      "ecr:UploadLayerPart"
+      "ecr:UploadLayerPart",
     ]
 
     effect = "Allow"
 
     resources = [
-      "*"
+      "*",
     ]
   }
 }
 
-resource "aws_iam_policy_attachment" "default" {
+resource "aws_iam_role_policy_attachment" "default" {
   name       = "${module.label.id}"
   policy_arn = "${aws_iam_policy.default.arn}"
-  roles      = ["${aws_iam_role.default.id}"]
+  role       = "${aws_iam_role.default.id}"
 }
 
 resource "aws_codebuild_project" "default" {

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 # Define composite variables for resources
 module "label" {
-  source    = "git::https://github.com/cloudposse/tf_label.git?ref=tags/0.1.0"
+  source    = "git::https://github.com/cloudposse/tf_label.git?ref=tags/0.2.0"
   namespace = "${var.namespace}"
   name      = "${var.name}"
   stage     = "${var.stage}"


### PR DESCRIPTION
## What

* Changed `aws_iam_policy_attachment` to `aws_iam_role_policy_attachment`


## Why

* The `aws_iam_policy_attachment` resource creates exclusive attachments of IAM policies. Across the entire AWS account, all of the `users/roles/groups` to which a single policy is attached must be declared by a single `aws_iam_policy_attachment` resource. This means that even any `users/roles/groups` that have the attached policy via some mechanism other than Terraform will have that attached policy revoked by Terraform


## References

* https://www.terraform.io/docs/providers/aws/r/iam_policy_attachment.html
