### PR TITLE
Propagate `attributes` and `tags` from `variables.tf` to the internal `label` module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,12 @@
 # Define composite variables for resources
 module "label" {
-  source    = "git::https://github.com/cloudposse/tf_label.git?ref=tags/0.2.0"
-  namespace = "${var.namespace}"
-  name      = "${var.name}"
-  stage     = "${var.stage}"
+  source     = "git::https://github.com/cloudposse/tf_label.git?ref=tags/0.2.0"
+  namespace  = "${var.namespace}"
+  name       = "${var.name}"
+  stage      = "${var.stage}"
+  delimiter  = "${var.delimiter}"
+  attributes = "${var.attributes}"
+  tags       = "${var.tags}"
 }
 
 resource "aws_iam_role" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -22,3 +22,18 @@ variable "buildspec" {
   default     = ""
   description = "Optional buildspec declaration to use for building the project"
 }
+
+variable "delimiter" {
+  type    = "string"
+  default = "-"
+}
+
+variable "attributes" {
+  type    = "list"
+  default = []
+}
+
+variable "tags" {
+  type    = "map"
+  default = {}
+}


### PR DESCRIPTION
## What

* Propagate `attributes` and `tags` from `variables.tf` to the internal `label` module


## Why

* The internal `label` module's `attributes` and `tags` should be visible from outside of the top-level module
* Since `attributes` and `tags` are not accesible from outside of the module, in some cases it's impossible to create more than one AWS resource
