### PR TITLE
Add `privileged_mode` attribute to `aws_codebuild_project`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -62,7 +62,6 @@ data "aws_iam_policy_document" "permissions" {
 }
 
 resource "aws_iam_role_policy_attachment" "default" {
-  name       = "${module.label.id}"
   policy_arn = "${aws_iam_policy.default.arn}"
   role       = "${aws_iam_role.default.id}"
 }
@@ -79,6 +78,7 @@ resource "aws_codebuild_project" "default" {
     compute_type = "${var.instance_size}"
     image        = "${var.image}"
     type         = "LINUX_CONTAINER"
+    privileged_mode = true
   }
 
   source {

--- a/main.tf
+++ b/main.tf
@@ -75,9 +75,9 @@ resource "aws_codebuild_project" "default" {
   }
 
   environment {
-    compute_type = "${var.instance_size}"
-    image        = "${var.image}"
-    type         = "LINUX_CONTAINER"
+    compute_type    = "${var.instance_size}"
+    image           = "${var.image}"
+    type            = "LINUX_CONTAINER"
     privileged_mode = true
   }
 


### PR DESCRIPTION
## What

* Add `privileged_mode` attribute to `aws_codebuild_project`
* Remove `name` attribute from `aws_iam_role_policy_attachment`


## Why

* `privileged_mode` attribute in `aws_codebuild_project` enables running the Docker daemon inside a `Docker` container (required when deploying `Docker` images on `Elastic Beanstalk`)

* `aws_iam_role_policy_attachment` does not have `name` attribute


## References

* https://www.terraform.io/docs/providers/aws/r/codebuild_project.html#privileged_mode
* https://www.terraform.io/docs/providers/aws/r/iam_role_policy_attachment.html
