### PR TITLE
Add `environment_variables` for building `Docker` images and pushing to `ECR`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ module "build" {
     name                = "ci"
     stage               = "staging"
     
-    image               = "apline"
+    image               = "aws/codebuild/docker:1.12.1"
     instance_size       = "BUILD_GENERAL1_SMALL"
     
     # These attributes are optional, used as ENV variables when building Docker images and pushing them to ECR
@@ -41,19 +41,19 @@ resource "aws_iam_role_policy_attachment" "codebuild_s3" {
 
 ## Input
 
-| Name            | Default              | Description                                                                                                                                  |
-|:---------------:|:--------------------:|:-------------------------------------------------------------------------------------------------------------------------------------------:|
-| namespace       | global               | Namespace                                                                                                                                   |
-| stage           | default              | Stage                                                                                                                                       |
-| name            | codebuild            | Name                                                                                                                                        |
-| image           | ""                   | Docker image used for build environment, _e.g._ `aws/codebuild/docker:1.12.1` or `aws/codebuild/eb-nodejs-6.10.0-amazonlinux-64:4.0.0`      |
-| instance_size   | BUILD_GENERAL1_SMALL | CodeBuild instance size.  Possible values are: ```BUILD_GENERAL1_SMALL``` ```BUILD_GENERAL1_MEDIUM``` ```BUILD_GENERAL1_LARGE```            |
-| buildspec       | ""                   | Optional buildspec declaration to use for building the project                                                                              |
-| privileged_mode | ""                   | If set to true, enables running the Docker daemon inside a Docker container. Optional, used when building Docker images                     |
-| aws_region      | ""                   | AWS Region for the ECR repository, _e.g._ `us-east-1`. Optional, used as ENV variable when building Docker images and pushing them to ECR   |
-| aws_account_id  | ""                   | AWS Account ID that owns the ECR repository. Optional, used as ENV variable when building Docker images and pushing them to ECR             |
-| image_repo_name | ""                   | ECR repository name to store Docker images. Optional, used as ENV variable when building Docker images and pushing them to ECR              |
-| image_tag       | ""                   | Docker image tag in the ECR repository, _e.g._ `latest`. Optional, used as ENV variable when building Docker images and pushing them to ECR |
+| Name            | Default              | Description                                                                                                                                          |
+|:---------------:|:--------------------:|:----------------------------------------------------------------------------------------------------------------------------------------------------:|
+| namespace       | global               | Namespace                                                                                                                                            |
+| stage           | default              | Stage                                                                                                                                                |
+| name            | codebuild            | Name                                                                                                                                                 |
+| image           | ""                   | Docker image used for build environment, _e.g._ `aws/codebuild/docker:1.12.1` or `aws/codebuild/eb-nodejs-6.10.0-amazonlinux-64:4.0.0`               |
+| instance_size   | BUILD_GENERAL1_SMALL | CodeBuild instance size.  Possible values are: ```BUILD_GENERAL1_SMALL``` ```BUILD_GENERAL1_MEDIUM``` ```BUILD_GENERAL1_LARGE```                     |
+| buildspec       | ""                   | Optional buildspec declaration to use for building the project                                                                                       |
+| privileged_mode | ""                   | (Optional) If set to true, enables running the Docker daemon inside a Docker container on the `CodeBuild` instance. Used when building Docker images |
+| aws_region      | ""                   | (Optional) AWS Region for the ECR repository, _e.g._ `us-east-1`. Used as `CodeBuild` ENV variable when building Docker images                       |
+| aws_account_id  | ""                   | (Optional) AWS Account ID that owns the ECR repository. Used as `CodeBuild` ENV variable when building Docker images                                 |
+| image_repo_name | ""                   | (Optional) ECR repository name to store Docker images. Used as `CodeBuild` ENV variable when building Docker images                                  |
+| image_tag       | ""                   | (Optional) Docker image tag in the ECR repository, _e.g._ `latest`. Used as `CodeBuild` ENV variable when building Docker images                     |
 
 
 

--- a/README.md
+++ b/README.md
@@ -30,14 +30,6 @@ module "build" {
 }
 ```
 
-Grant the required permissions to s3
-
-```
-resource "aws_iam_role_policy_attachment" "codebuild_s3" {
-  role   = "${module.build.role_arn}"
-  policy_arn = "${aws_iam_policy.s3.arn}"
-}
-```
 
 
 ## Input

--- a/README.md
+++ b/README.md
@@ -34,19 +34,19 @@ module "build" {
 
 ## Input
 
-| Name                | Default              | Description                                                                                                                                          |
-|:-------------------:|:--------------------:|:----------------------------------------------------------------------------------------------------------------------------------------------------:|
-| namespace           | global               | Namespace                                                                                                                                            |
-| stage               | default              | Stage                                                                                                                                                |
-| name                | codebuild            | Name                                                                                                                                                 |
-| build_image         | (Required)           | Docker image for build environment, _e.g._ `aws/codebuild/docker:1.12.1` or `aws/codebuild/eb-nodejs-6.10.0-amazonlinux-64:4.0.0`                    |
-| build_compute_type  | BUILD_GENERAL1_SMALL | CodeBuild instance size.  Possible values are: ```BUILD_GENERAL1_SMALL``` ```BUILD_GENERAL1_MEDIUM``` ```BUILD_GENERAL1_LARGE```                     |
-| buildspec           | ""                   | (Optional) `buildspec` declaration to use for building the project                                                                                   |
-| privileged_mode     | ""                   | (Optional) If set to true, enables running the Docker daemon inside a Docker container on the `CodeBuild` instance. Used when building Docker images |
-| aws_region          | ""                   | (Optional) AWS Region, _e.g._ `us-east-1`. Used as `CodeBuild` ENV variable when building Docker images                                              |
-| aws_account_id      | ""                   | (Optional) AWS Account ID. Used as `CodeBuild` ENV variable when building Docker images                                                              |
-| image_repo_name     | ""                   | (Optional) ECR repository name to store the Docker image built by this module. Used as `CodeBuild` ENV variable when building Docker images          |
-| image_tag           | ""                   | (Optional) Docker image tag in the ECR repository, _e.g._ `latest`. Used as `CodeBuild` ENV variable when building Docker images                     |
+| Name                | Default                      | Description                                                                                                                                          |
+|:-------------------:|:----------------------------:|:----------------------------------------------------------------------------------------------------------------------------------------------------:|
+| namespace           | global                       | Namespace                                                                                                                                            |
+| stage               | default                      | Stage                                                                                                                                                |
+| name                | codebuild                    | Name                                                                                                                                                 |
+| build_image         | aws/codebuild/docker:1.12.1  | Docker image for build environment, _e.g._ `aws/codebuild/docker:1.12.1` or `aws/codebuild/eb-nodejs-6.10.0-amazonlinux-64:4.0.0`                    |
+| build_compute_type  | BUILD_GENERAL1_SMALL         | `CodeBuild` instance size.  Possible values are: ```BUILD_GENERAL1_SMALL``` ```BUILD_GENERAL1_MEDIUM``` ```BUILD_GENERAL1_LARGE```                   |
+| buildspec           | ""                           | (Optional) `buildspec` declaration to use for building the project                                                                                   |
+| privileged_mode     | ""                           | (Optional) If set to true, enables running the Docker daemon inside a Docker container on the `CodeBuild` instance. Used when building Docker images |
+| aws_region          | ""                           | (Optional) AWS Region, _e.g._ `us-east-1`. Used as `CodeBuild` ENV variable when building Docker images                                              |
+| aws_account_id      | ""                           | (Optional) AWS Account ID. Used as `CodeBuild` ENV variable when building Docker images                                                              |
+| image_repo_name     | ""                           | (Optional) ECR repository name to store the Docker image built by this module. Used as `CodeBuild` ENV variable when building Docker images          |
+| image_tag           | ""                           | (Optional) Docker image tag in the ECR repository, _e.g._ `latest`. Used as `CodeBuild` ENV variable when building Docker images                     |
 
 
 

--- a/README.md
+++ b/README.md
@@ -34,19 +34,19 @@ module "build" {
 
 ## Input
 
-| Name            | Default              | Description                                                                                                                                          |
-|:---------------:|:--------------------:|:----------------------------------------------------------------------------------------------------------------------------------------------------:|
-| namespace       | global               | Namespace                                                                                                                                            |
-| stage           | default              | Stage                                                                                                                                                |
-| name            | codebuild            | Name                                                                                                                                                 |
-| build_image     | (Required)           | Docker image for build environment, _e.g._ `aws/codebuild/docker:1.12.1` or `aws/codebuild/eb-nodejs-6.10.0-amazonlinux-64:4.0.0`                    |
-| instance_size   | BUILD_GENERAL1_SMALL | CodeBuild instance size.  Possible values are: ```BUILD_GENERAL1_SMALL``` ```BUILD_GENERAL1_MEDIUM``` ```BUILD_GENERAL1_LARGE```                     |
-| buildspec       | ""                   | (Optional) `buildspec` declaration to use for building the project                                                                                   |
-| privileged_mode | ""                   | (Optional) If set to true, enables running the Docker daemon inside a Docker container on the `CodeBuild` instance. Used when building Docker images |
-| aws_region      | ""                   | (Optional) AWS Region, _e.g._ `us-east-1`. Used as `CodeBuild` ENV variable when building Docker images                                              |
-| aws_account_id  | ""                   | (Optional) AWS Account ID. Used as `CodeBuild` ENV variable when building Docker images                                                              |
-| image_repo_name | ""                   | (Optional) ECR repository name to store Docker images. Used as `CodeBuild` ENV variable when building Docker images                                  |
-| image_tag       | ""                   | (Optional) Docker image tag in the ECR repository, _e.g._ `latest`. Used as `CodeBuild` ENV variable when building Docker images                     |
+| Name                | Default              | Description                                                                                                                                          |
+|:-------------------:|:--------------------:|:----------------------------------------------------------------------------------------------------------------------------------------------------:|
+| namespace           | global               | Namespace                                                                                                                                            |
+| stage               | default              | Stage                                                                                                                                                |
+| name                | codebuild            | Name                                                                                                                                                 |
+| build_image         | (Required)           | Docker image for build environment, _e.g._ `aws/codebuild/docker:1.12.1` or `aws/codebuild/eb-nodejs-6.10.0-amazonlinux-64:4.0.0`                    |
+| build_compute_type  | BUILD_GENERAL1_SMALL | CodeBuild instance size.  Possible values are: ```BUILD_GENERAL1_SMALL``` ```BUILD_GENERAL1_MEDIUM``` ```BUILD_GENERAL1_LARGE```                     |
+| buildspec           | ""                   | (Optional) `buildspec` declaration to use for building the project                                                                                   |
+| privileged_mode     | ""                   | (Optional) If set to true, enables running the Docker daemon inside a Docker container on the `CodeBuild` instance. Used when building Docker images |
+| aws_region          | ""                   | (Optional) AWS Region, _e.g._ `us-east-1`. Used as `CodeBuild` ENV variable when building Docker images                                              |
+| aws_account_id      | ""                   | (Optional) AWS Account ID. Used as `CodeBuild` ENV variable when building Docker images                                                              |
+| image_repo_name     | ""                   | (Optional) ECR repository name to store the Docker image built by this module. Used as `CodeBuild` ENV variable when building Docker images          |
+| image_tag           | ""                   | (Optional) Docker image tag in the ECR repository, _e.g._ `latest`. Used as `CodeBuild` ENV variable when building Docker images                     |
 
 
 

--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ resource "aws_iam_role_policy_attachment" "codebuild_s3" {
 | name            | codebuild            | Name                                                                                                                                                 |
 | image           | ""                   | Docker image used for build environment, _e.g._ `aws/codebuild/docker:1.12.1` or `aws/codebuild/eb-nodejs-6.10.0-amazonlinux-64:4.0.0`               |
 | instance_size   | BUILD_GENERAL1_SMALL | CodeBuild instance size.  Possible values are: ```BUILD_GENERAL1_SMALL``` ```BUILD_GENERAL1_MEDIUM``` ```BUILD_GENERAL1_LARGE```                     |
-| buildspec       | ""                   | Optional buildspec declaration to use for building the project                                                                                       |
+| buildspec       | ""                   | (Optional) `buildspec` declaration to use for building the project                                                                                       |
 | privileged_mode | ""                   | (Optional) If set to true, enables running the Docker daemon inside a Docker container on the `CodeBuild` instance. Used when building Docker images |
-| aws_region      | ""                   | (Optional) AWS Region for the ECR repository, _e.g._ `us-east-1`. Used as `CodeBuild` ENV variable when building Docker images                       |
-| aws_account_id  | ""                   | (Optional) AWS Account ID that owns the ECR repository. Used as `CodeBuild` ENV variable when building Docker images                                 |
+| aws_region      | ""                   | (Optional) AWS Region, _e.g._ `us-east-1`. Used as `CodeBuild` ENV variable when building Docker images                                              |
+| aws_account_id  | ""                   | (Optional) AWS Account ID. Used as `CodeBuild` ENV variable when building Docker images                                                              |
 | image_repo_name | ""                   | (Optional) ECR repository name to store Docker images. Used as `CodeBuild` ENV variable when building Docker images                                  |
 | image_tag       | ""                   | (Optional) Docker image tag in the ECR repository, _e.g._ `latest`. Used as `CodeBuild` ENV variable when building Docker images                     |
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ module "build" {
     
     # http://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref.html
     build_image         = "aws/codebuild/docker:1.12.1"
-    instance_size       = "BUILD_GENERAL1_SMALL"
+    build_compute_type  = "BUILD_GENERAL1_SMALL"
     
     # These attributes are optional, used as ENV variables when building Docker images and pushing them to ECR
     # For more info:

--- a/README.md
+++ b/README.md
@@ -8,17 +8,28 @@ Include this repository as a module in your existing terraform code:
 
 ```
 module "build" {
-  source    = "git::https://github.com/cloudposse/tf_codebuild.git"
-  namespace = "general"
-  name      = "ci"
-  stage     = "staging"
-
-  image         = "apline"
-  instance_size = "BUILD_GENERAL1_SMALL"
+    source              = "git::https://github.com/cloudposse/tf_codebuild.git?ref=tags/0.5.0"
+    namespace           = "general"
+    name                = "ci"
+    stage               = "staging"
+    
+    image               = "apline"
+    instance_size       = "BUILD_GENERAL1_SMALL"
+    
+    # These attributes are optional, used as ENV variables when building Docker images and pushing them to ECR
+    # For more info:
+    # http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html
+    # https://www.terraform.io/docs/providers/aws/r/codebuild_project.html
+    
+    privileged_mode     = true
+    aws_region          = "us-east-1"
+    aws_account_id      = "xxxxxxxxxx"
+    image_repo_name     = "ecr-repo-name"
+    image_tag           = "latest"
 }
 ```
 
-Grant appropriate permsissions to s3
+Grant the required permissions to s3
 
 ```
 resource "aws_iam_role_policy_attachment" "codebuild_s3" {
@@ -27,21 +38,29 @@ resource "aws_iam_role_policy_attachment" "codebuild_s3" {
 }
 ```
 
+
 ## Input
 
-| Name          | Default              | Decription                                                                                                                     |
-|:-------------:|:--------------------:|:------------------------------------------------------------------------------------------------------------------------------:|
-| namespace     | global               | Namespace                                                                                                                      |
-| stage         | default              | Stage                                                                                                                          |
-| name          | codebuild            | Name                                                                                                                           |
-| image         | alpine               | Docker image used as environment                                                                                               |
-| instance_size | BUILD_GENERAL1_SMALL | Instance size for job.  Possible values are: ```BUILD_GENERAL1_SMALL``` ```BUILD_GENERAL1_MEDIUM``` ```BUILD_GENERAL1_LARGE``` |
-| buildspec     | ""                   | Optional buildspec declaration to use for building the project                                                                 |
+| Name            | Default              | Description                                                                                                                                  |
+|:---------------:|:--------------------:|:-------------------------------------------------------------------------------------------------------------------------------------------:|
+| namespace       | global               | Namespace                                                                                                                                   |
+| stage           | default              | Stage                                                                                                                                       |
+| name            | codebuild            | Name                                                                                                                                        |
+| image           | ""                   | Docker image used for build environment, _e.g._ `aws/codebuild/docker:1.12.1` or `aws/codebuild/eb-nodejs-6.10.0-amazonlinux-64:4.0.0`      |
+| instance_size   | BUILD_GENERAL1_SMALL | CodeBuild instance size.  Possible values are: ```BUILD_GENERAL1_SMALL``` ```BUILD_GENERAL1_MEDIUM``` ```BUILD_GENERAL1_LARGE```            |
+| buildspec       | ""                   | Optional buildspec declaration to use for building the project                                                                              |
+| privileged_mode | ""                   | If set to true, enables running the Docker daemon inside a Docker container. Optional, used when building Docker images                     |
+| aws_region      | ""                   | AWS Region for the ECR repository, _e.g._ `us-east-1`. Optional, used as ENV variable when building Docker images and pushing them to ECR   |
+| aws_account_id  | ""                   | AWS Account ID that owns the ECR repository. Optional, used as ENV variable when building Docker images and pushing them to ECR             |
+| image_repo_name | ""                   | ECR repository name to store Docker images. Optional, used as ENV variable when building Docker images and pushing them to ECR              |
+| image_tag       | ""                   | Docker image tag in the ECR repository, _e.g._ `latest`. Optional, used as ENV variable when building Docker images and pushing them to ECR |
+
+
 
 ## Output
 
 | Name         | Decription             |
 |:------------:|:----------------------:|
 | project_name | CodeBuild project name |
-| project_id   | CodeBuild project arn  |
-| role_arn     | IAM Role arn           |
+| project_id   | CodeBuild project ARN  |
+| role_arn     | IAM Role ARN           |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ module "build" {
     name                = "ci"
     stage               = "staging"
     
-    image               = "aws/codebuild/docker:1.12.1"
+    # http://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref.html
+    build_image         = "aws/codebuild/docker:1.12.1"
     instance_size       = "BUILD_GENERAL1_SMALL"
     
     # These attributes are optional, used as ENV variables when building Docker images and pushing them to ECR
@@ -46,9 +47,9 @@ resource "aws_iam_role_policy_attachment" "codebuild_s3" {
 | namespace       | global               | Namespace                                                                                                                                            |
 | stage           | default              | Stage                                                                                                                                                |
 | name            | codebuild            | Name                                                                                                                                                 |
-| image           | ""                   | Docker image used for build environment, _e.g._ `aws/codebuild/docker:1.12.1` or `aws/codebuild/eb-nodejs-6.10.0-amazonlinux-64:4.0.0`               |
+| build_image     | (Required)           | Docker image for build environment, _e.g._ `aws/codebuild/docker:1.12.1` or `aws/codebuild/eb-nodejs-6.10.0-amazonlinux-64:4.0.0`                    |
 | instance_size   | BUILD_GENERAL1_SMALL | CodeBuild instance size.  Possible values are: ```BUILD_GENERAL1_SMALL``` ```BUILD_GENERAL1_MEDIUM``` ```BUILD_GENERAL1_LARGE```                     |
-| buildspec       | ""                   | (Optional) `buildspec` declaration to use for building the project                                                                                       |
+| buildspec       | ""                   | (Optional) `buildspec` declaration to use for building the project                                                                                   |
 | privileged_mode | ""                   | (Optional) If set to true, enables running the Docker daemon inside a Docker container on the `CodeBuild` instance. Used when building Docker images |
 | aws_region      | ""                   | (Optional) AWS Region, _e.g._ `us-east-1`. Used as `CodeBuild` ENV variable when building Docker images                                              |
 | aws_account_id  | ""                   | (Optional) AWS Account ID. Used as `CodeBuild` ENV variable when building Docker images                                                              |

--- a/main.tf
+++ b/main.tf
@@ -78,7 +78,27 @@ resource "aws_codebuild_project" "default" {
     compute_type    = "${var.instance_size}"
     image           = "${var.image}"
     type            = "LINUX_CONTAINER"
-    privileged_mode = true
+    privileged_mode = "${var.privileged_mode}"
+
+    environment_variable {
+      "name"  = "AWS_REGION"
+      "value" = "${var.aws_region}"
+    }
+
+    environment_variable {
+      "name"  = "AWS_ACCOUNT_ID"
+      "value" = "${var.aws_account_id}"
+    }
+
+    environment_variable {
+      "name"  = "IMAGE_REPO_NAME"
+      "value" = "${var.image_repo_name}"
+    }
+
+    environment_variable {
+      "name"  = "IMAGE_TAG"
+      "value" = "${var.image_tag}"
+    }
   }
 
   source {

--- a/main.tf
+++ b/main.tf
@@ -62,7 +62,7 @@ data "aws_iam_policy_document" "permissions" {
     effect = "Allow"
 
     resources = [
-      "*",
+      "*"
     ]
   }
 }
@@ -82,7 +82,7 @@ resource "aws_codebuild_project" "default" {
 
   environment {
     compute_type    = "${var.instance_size}"
-    image           = "${var.image}"
+    image           = "${var.build_image}"
     type            = "LINUX_CONTAINER"
     privileged_mode = "${var.privileged_mode}"
 

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,9 @@
 data "aws_caller_identity" "current" {}
 
+data "aws_region" "current" {
+  current = true
+}
+
 # Define composite variables for resources
 module "label" {
   source     = "git::https://github.com/cloudposse/tf_label.git?ref=tags/0.2.0"
@@ -84,7 +88,7 @@ resource "aws_codebuild_project" "default" {
 
     environment_variable {
       "name"  = "AWS_REGION"
-      "value" = "${var.aws_region}"
+      "value" = "${signum(length(var.aws_region)) == 1 ? var.aws_region : data.aws_region.current.name}"
     }
 
     environment_variable {

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,5 @@
+data "aws_caller_identity" "current" {}
+
 # Define composite variables for resources
 module "label" {
   source     = "git::https://github.com/cloudposse/tf_label.git?ref=tags/0.2.0"
@@ -87,7 +89,7 @@ resource "aws_codebuild_project" "default" {
 
     environment_variable {
       "name"  = "AWS_ACCOUNT_ID"
-      "value" = "${var.aws_account_id}"
+      "value" = "${signum(length(var.aws_account_id)) == 1 ? var.aws_account_id : data.aws_caller_identity.current.account_id}"
     }
 
     environment_variable {

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
-data "aws_caller_identity" "current" {}
+data "aws_caller_identity" "default" {}
 
-data "aws_region" "current" {
+data "aws_region" "default" {
   current = true
 }
 
@@ -88,12 +88,12 @@ resource "aws_codebuild_project" "default" {
 
     environment_variable {
       "name"  = "AWS_REGION"
-      "value" = "${signum(length(var.aws_region)) == 1 ? var.aws_region : data.aws_region.current.name}"
+      "value" = "${signum(length(var.aws_region)) == 1 ? var.aws_region : data.aws_region.default.name}"
     }
 
     environment_variable {
       "name"  = "AWS_ACCOUNT_ID"
-      "value" = "${signum(length(var.aws_account_id)) == 1 ? var.aws_account_id : data.aws_caller_identity.current.account_id}"
+      "value" = "${signum(length(var.aws_account_id)) == 1 ? var.aws_account_id : data.aws_caller_identity.default.account_id}"
     }
 
     environment_variable {

--- a/main.tf
+++ b/main.tf
@@ -81,7 +81,7 @@ resource "aws_codebuild_project" "default" {
   }
 
   environment {
-    compute_type    = "${var.instance_size}"
+    compute_type    = "${var.build_compute_type}"
     image           = "${var.build_image}"
     type            = "LINUX_CONTAINER"
     privileged_mode = "${var.privileged_mode}"

--- a/main.tf
+++ b/main.tf
@@ -62,7 +62,7 @@ data "aws_iam_policy_document" "permissions" {
     effect = "Allow"
 
     resources = [
-      "*"
+      "*",
     ]
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -12,7 +12,7 @@ variable "name" {
 
 variable "build_image" {}
 
-variable "instance_size" {
+variable "build_compute_type" {
   default = "BUILD_GENERAL1_SMALL"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -39,25 +39,30 @@ variable "tags" {
 }
 
 variable "privileged_mode" {
-  default = false
+  default     = false
+  description = "(Optional, used when building Docker images). If set to true, enables running the Docker daemon inside a Docker container."
 }
 
 variable "aws_region" {
-  type    = "string"
-  default = ""
+  type        = "string"
+  default     = ""
+  description = "(Optional, used when building Docker images and pushing them to ECR). AWS Region for the ECR repository, e.g. us-east-1. For more info: http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html"
 }
 
 variable "aws_account_id" {
-  type    = "string"
-  default = ""
+  type        = "string"
+  default     = ""
+  description = "(Optional, used when building Docker images and pushing them to ECR). AWS Account ID that owns the ECR repository. For more info: http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html"
 }
 
 variable "image_repo_name" {
-  type    = "string"
-  default = ""
+  type        = "string"
+  default     = ""
+  description = "(Optional, used when building Docker images and pushing them to ECR). ECR repository name to store Docker images. For more info: http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html"
 }
 
 variable "image_tag" {
-  type    = "string"
-  default = ""
+  type        = "string"
+  default     = ""
+  description = "(Optional, used when building Docker images and pushing them to ECR). Docker image tag in the ECR repository, e.g. 'latest'. For more info: http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -11,7 +11,6 @@ variable "name" {
 }
 
 variable "image" {
-  default = ""
 }
 
 variable "instance_size" {

--- a/variables.tf
+++ b/variables.tf
@@ -56,7 +56,7 @@ variable "aws_account_id" {
 variable "image_repo_name" {
   type        = "string"
   default     = ""
-  description = "(Optional) ECR repository name to store Docker images. Used as CodeBuild ENV variable when building Docker images. For more info: http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html"
+  description = "(Optional) ECR repository name to store the Docker image built by this module. Used as CodeBuild ENV variable when building Docker images. For more info: http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html"
 }
 
 variable "image_tag" {

--- a/variables.tf
+++ b/variables.tf
@@ -10,8 +10,7 @@ variable "name" {
   default = "codebuild"
 }
 
-variable "image" {
-}
+variable "build_image" {}
 
 variable "instance_size" {
   default = "BUILD_GENERAL1_SMALL"

--- a/variables.tf
+++ b/variables.tf
@@ -40,29 +40,29 @@ variable "tags" {
 
 variable "privileged_mode" {
   default     = false
-  description = "(Optional, used when building Docker images). If set to true, enables running the Docker daemon inside a Docker container."
+  description = "(Optional) If set to true, enables running the Docker daemon inside a Docker container on the CodeBuild instance. Used when building Docker images"
 }
 
 variable "aws_region" {
   type        = "string"
   default     = ""
-  description = "(Optional, used as ENV variable when building Docker images and pushing them to ECR). AWS Region for the ECR repository, e.g. us-east-1. For more info: http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html"
+  description = "(Optional) AWS Region, e.g. us-east-1. Used as CodeBuild ENV variable when building Docker images. For more info: http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html"
 }
 
 variable "aws_account_id" {
   type        = "string"
   default     = ""
-  description = "(Optional, used as ENV variable when building Docker images and pushing them to ECR). AWS Account ID that owns the ECR repository. For more info: http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html"
+  description = "(Optional) AWS Account ID. Used as CodeBuild ENV variable when building Docker images. For more info: http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html"
 }
 
 variable "image_repo_name" {
   type        = "string"
   default     = ""
-  description = "(Optional, used as ENV variable when building Docker images and pushing them to ECR). ECR repository name to store Docker images. For more info: http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html"
+  description = "(Optional) ECR repository name to store Docker images. Used as CodeBuild ENV variable when building Docker images. For more info: http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html"
 }
 
 variable "image_tag" {
   type        = "string"
   default     = ""
-  description = "(Optional, used as ENV variable when building Docker images and pushing them to ECR). Docker image tag in the ECR repository, e.g. 'latest'. For more info: http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html"
+  description = "(Optional) Docker image tag in the ECR repository, e.g. 'latest'. Used as CodeBuild ENV variable when building Docker images. For more info: http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -37,3 +37,27 @@ variable "tags" {
   type    = "map"
   default = {}
 }
+
+variable "privileged_mode" {
+  default = false
+}
+
+variable "aws_region" {
+  type    = "string"
+  default = ""
+}
+
+variable "aws_account_id" {
+  type    = "string"
+  default = ""
+}
+
+variable "image_repo_name" {
+  type    = "string"
+  default = ""
+}
+
+variable "image_tag" {
+  type    = "string"
+  default = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -10,7 +10,10 @@ variable "name" {
   default = "codebuild"
 }
 
-variable "build_image" {}
+variable "build_image" {
+  default     = "aws/codebuild/docker:1.12.1"
+  description = "Docker image for build environment, e.g. 'aws/codebuild/docker:1.12.1' or 'aws/codebuild/eb-nodejs-6.10.0-amazonlinux-64:4.0.0'. For more info: http://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref.html"
+}
 
 variable "build_compute_type" {
   default = "BUILD_GENERAL1_SMALL"

--- a/variables.tf
+++ b/variables.tf
@@ -11,7 +11,7 @@ variable "name" {
 }
 
 variable "image" {
-  default = "alpine"
+  default = ""
 }
 
 variable "instance_size" {
@@ -46,23 +46,23 @@ variable "privileged_mode" {
 variable "aws_region" {
   type        = "string"
   default     = ""
-  description = "(Optional, used when building Docker images and pushing them to ECR). AWS Region for the ECR repository, e.g. us-east-1. For more info: http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html"
+  description = "(Optional, used as ENV variable when building Docker images and pushing them to ECR). AWS Region for the ECR repository, e.g. us-east-1. For more info: http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html"
 }
 
 variable "aws_account_id" {
   type        = "string"
   default     = ""
-  description = "(Optional, used when building Docker images and pushing them to ECR). AWS Account ID that owns the ECR repository. For more info: http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html"
+  description = "(Optional, used as ENV variable when building Docker images and pushing them to ECR). AWS Account ID that owns the ECR repository. For more info: http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html"
 }
 
 variable "image_repo_name" {
   type        = "string"
   default     = ""
-  description = "(Optional, used when building Docker images and pushing them to ECR). ECR repository name to store Docker images. For more info: http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html"
+  description = "(Optional, used as ENV variable when building Docker images and pushing them to ECR). ECR repository name to store Docker images. For more info: http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html"
 }
 
 variable "image_tag" {
   type        = "string"
   default     = ""
-  description = "(Optional, used when building Docker images and pushing them to ECR). Docker image tag in the ECR repository, e.g. 'latest'. For more info: http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html"
+  description = "(Optional, used as ENV variable when building Docker images and pushing them to ECR). Docker image tag in the ECR repository, e.g. 'latest'. For more info: http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html"
 }


### PR DESCRIPTION
## What

* Added `environment_variables` for building `Docker` images and pushing them to `AWS ECR`


## Why

* The `environment_variables` in the `CodeBuild` build instance will allow using a generic `buildspec.yml` file in the application repository without hardcoding any deployment-related values. 
(Note: `buildspec.yml` is stored in the application repository but gets executed by `CodeBuild` on the build instance)

```
phases:
  pre_build:
    commands:
      - echo Logging in to Amazon ECR...
      - $(aws ecr get-login --region $AWS_REGION)
  build:
    commands:
      - echo Build started on `date`
      - echo Building the Docker image...
      - docker build -t $IMAGE_REPO_NAME .
      - docker tag $IMAGE_REPO_NAME:$IMAGE_TAG $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG
  post_build:
    commands:
      - echo Build completed on `date`
      - echo Pushing the Docker image to ECR...
      - docker push $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG
```


## References

* https://www.terraform.io/docs/providers/aws/r/codebuild_project.html
* http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html
